### PR TITLE
Add i18n support and stabilize Cypress tests

### DIFF
--- a/app/categories/page.tsx
+++ b/app/categories/page.tsx
@@ -162,30 +162,42 @@ const CategoriesPage: React.FC = () => {
       </div>
 
       <ul
-  className="list-disc space-y-2 pl-5"
-  data-testid="category-list-items"
-  data-cy="category-list-items"
->
-  {categories?.map((category) => (
-    <li key={category._id} className="flex justify-between items-center">
-      <span
-        data-testid={`category-name-${category._id}`}
-        data-cy={`category-name-${category._id}`}
+        className="list-disc space-y-2 pl-5"
+        data-testid="category-list-items"
+        data-cy="category-list-items"
       >
-        {category.name}
-      </span>
-      <button
-        data-testid={`delete-category-${category._id}`}
-        data-cy={`delete-category-${category._id}`}
-        onClick={() => deleteCategory(category._id)}
-        className="ml-2 px-4 py-2 rounded bg-red-500 text-white hover:bg-red-700 transition"
-      >
-        <FaRegTrashAlt />
-      </button>
-    </li>
-  ))}
-</ul>
-
+        {categories && categories.length > 0 ? (
+          categories.map((category) => (
+            <li
+              key={category._id}
+              className="flex justify-between items-center"
+            >
+              <span
+                data-testid={`category-name-${category._id}`}
+                data-cy={`category-name-${category._id}`}
+              >
+                {category.name}
+              </span>
+              <button
+                data-testid={`delete-category-${category._id}`}
+                data-cy={`delete-category-${category._id}`}
+                onClick={() => deleteCategory(category._id)}
+                className="ml-2 px-4 py-2 rounded bg-red-500 text-white hover:bg-red-700 transition"
+              >
+                <FaRegTrashAlt />
+              </button>
+            </li>
+          ))
+        ) : (
+          <p
+            data-testid="no-categories-message"
+            data-cy="no-categories-message"
+            className="text-gray-500"
+          >
+            {t("categories.emptyMessage")}
+          </p>
+        )}
+      </ul>
     </div>
   );
 };

--- a/cypress/e2e/authenticated_redirection.cy.ts
+++ b/cypress/e2e/authenticated_redirection.cy.ts
@@ -1,16 +1,17 @@
 /**
  * authenticated_redirection.cy.ts
  *
- * Tests for authenticated user redirections and content verification.
+ * Tests for authenticated user redirections and content verification with enhanced logging and reliability improvements.
  */
 
 /// <reference types="cypress" />
 
-import { navigateAndVerify, checkElementVisibility } from "../support/utils";
+import { checkElementVisibility } from "../support/utils";
 
 describe("Authenticated User Redirection", () => {
   before(() => {
     // Reset the user before the tests
+    cy.log("Resetting test user");
     cy.resetUser("test@example.com", "password123", {
       firstName: "Jane",
       lastName: "Smith",
@@ -21,18 +22,21 @@ describe("Authenticated User Redirection", () => {
 
   beforeEach(() => {
     // Log in before each test
+    cy.log("Logging in the test user");
     cy.login("test@example.com", "password123", "/login");
 
-    // Navigate to the dashboard without verifying any specific element
+    // Navigate to the dashboard without verifying specific elements
+    cy.log("Navigating to /dashboard");
     cy.visit("/dashboard");
-    cy.url({ timeout: 15000 }).should("include", "/dashboard");
+    cy.url({ timeout: 20000 }).should("include", "/dashboard");
   });
 
   it("should redirect authenticated users from /login to /dashboard", () => {
-    // Navigate to /login and verify redirection to the dashboard
-    navigateAndVerify("/login", "/dashboard", '[data-cy="welcome-message"]');
+    cy.log("Verifying redirection from /login to /dashboard");
+    cy.visit("/login");
+    cy.url({ timeout: 20000 }).should("include", "/dashboard");
 
-    // Check if the welcome message is visible on the dashboard
+    cy.log("Checking if the welcome message is visible");
     checkElementVisibility(
       '[data-cy="welcome-message"]',
       "Welcome message is visible",
@@ -41,14 +45,11 @@ describe("Authenticated User Redirection", () => {
   });
 
   it("should display categories when redirected to categories page", () => {
-    // Navigate to /categories and verify the page loads successfully
-    navigateAndVerify(
-      "/categories",
-      "/categories",
-      '[data-cy="categories-form"]'
-    );
+    cy.log("Navigating to /categories");
+    cy.visit("/categories");
+    cy.url({ timeout: 20000 }).should("include", "/categories");
 
-    // Check if the categories form is visible
+    cy.log("Checking if the categories form is visible");
     checkElementVisibility(
       '[data-cy="categories-form"]',
       "Categories form is visible",
@@ -57,10 +58,11 @@ describe("Authenticated User Redirection", () => {
   });
 
   it("should display tasks when redirected to tasks page", () => {
-    // Navigate to /tasks and verify the page loads successfully
-    navigateAndVerify("/tasks", "/tasks", '[data-cy="todo-list"]');
+    cy.log("Navigating to /tasks");
+    cy.visit("/tasks");
+    cy.url({ timeout: 20000 }).should("include", "/tasks");
 
-    // Check if the todo list is visible
+    cy.log("Checking if the todo list is visible");
     checkElementVisibility(
       '[data-cy="todo-list"]',
       "Todo list is visible",
@@ -69,10 +71,11 @@ describe("Authenticated User Redirection", () => {
   });
 
   it("should display profile when redirected to profile page", () => {
-    // Navigate to /profile and verify the page loads successfully
-    navigateAndVerify("/profile", "/profile", '[data-cy="edit-profile-title"]');
+    cy.log("Navigating to /profile");
+    cy.visit("/profile");
+    cy.url({ timeout: 20000 }).should("include", "/profile");
 
-    // Check the visibility of the profile edit title element
+    cy.log("Checking if the profile edit title is visible");
     checkElementVisibility(
       '[data-cy="edit-profile-title"]',
       "Edit profile title is visible",
@@ -81,7 +84,7 @@ describe("Authenticated User Redirection", () => {
   });
 
   after(() => {
-    // Delete the test user after the tests
+    cy.log("Deleting the test user");
     cy.deleteUser("test@example.com", "password123");
   });
 });

--- a/cypress/e2e/categories.cy.ts
+++ b/cypress/e2e/categories.cy.ts
@@ -1,58 +1,144 @@
 /// <reference types="cypress" />
 
-import { navigateAndVerify } from "../support/utils";
+import { checkElementVisibility } from "../support/utils";
 
-describe("Authenticated User Redirection", () => {
-  before(() => {
-    // Reset user before tests
-    cy.resetUser("test@example.com", "password123", {
-      firstName: "Jane",
-      lastName: "Smith",
-      nickname: "JaneS",
-      username: "janesmith",
-    });
-  });
-
+describe("Categories Page", () => {
   beforeEach(() => {
-    // Log in before each test
-    cy.login("test@example.com", "password123", "/login");
+    // Mock for login endpoint
+    cy.intercept("POST", "/api/auth/login", {
+      statusCode: 200,
+      body: {
+        success: true,
+        token: "valid-token", // Simulates a valid authentication token
+      },
+    }).as("loginRequest");
 
-    // Verify login redirects to the dashboard
-    navigateAndVerify("/dashboard");
-  });
+    // Mock for authentication check endpoint
+    cy.intercept("GET", "/api/auth/check", {
+      statusCode: 200,
+      body: { success: true }, // Indicates the session is valid
+    }).as("authCheck");
 
-  it("should redirect authenticated users from /login to /dashboard", () => {
-    // Navigate to /login and verify redirection to /dashboard
+    // Mock for user profile endpoint
+    cy.intercept("GET", "/api/users/profile", {
+      statusCode: 200,
+      body: {
+        success: true,
+        user: {
+          id: "123",
+          name: "Test User",
+          email: "test@example.com",
+        },
+      },
+    }).as("userProfile");
+
+    // Mock for fetching categories
+    cy.intercept("GET", "/api/categories", {
+      statusCode: 200,
+      body: {
+        success: true,
+        categories: [
+          { _id: "1", name: "Work", description: "Work-related tasks" },
+          { _id: "2", name: "Personal", description: "Personal tasks" },
+        ],
+      },
+    }).as("categoriesRequest");
+
+    // Mock for adding a category
+    cy.intercept("POST", "/api/categories", {
+      statusCode: 201,
+      body: {
+        success: true,
+        category: { _id: "3", name: "New Category", description: "Test tasks" },
+      },
+    }).as("addCategoryRequest");
+
+    // Mock for deleting a category
+    cy.intercept("DELETE", "/api/categories/*", {
+      statusCode: 200,
+      body: { success: true }, // Indicates the category was successfully deleted
+    }).as("deleteCategoryRequest");
+
+    // Simulating login flow
+    cy.log("Visiting login page...");
     cy.visit("/login");
-    cy.url({ timeout: 15000 }).should("include", "/dashboard");
 
-    // Explicitly check visibility of welcome message
-    cy.get('[data-cy="welcome-message"]').should("be.visible");
+    cy.log("Logging in user...");
+    cy.get('input[id="email"]').type("test@example.com");
+    cy.get('input[id="password"]').type("password123");
+    cy.get('button[type="submit"]').click();
+    cy.wait("@loginRequest").its("response.statusCode").should("eq", 200);
+
+    // Navigating to the categories page
+    cy.log("Visiting categories page...");
+    cy.visit("/categories");
+    cy.wait("@categoriesRequest").its("response.statusCode").should("eq", 200);
   });
 
-  it("should display categories when redirected to categories page", () => {
-    navigateAndVerify("/categories");
-    cy.get('[data-cy="categories-form"]').should("be.visible");
+  it("should display categories from API", () => {
+    // Confirm the categories are loaded in the DOM
+    checkElementVisibility(
+      '[data-cy="category-name-1"]',
+      "Category 'Work' is visible",
+      "Category 'Work' is not visible"
+    );
+    checkElementVisibility(
+      '[data-cy="category-name-2"]',
+      "Category 'Personal' is visible",
+      "Category 'Personal' is not visible"
+    );
   });
 
-  it("should display tasks when redirected to tasks page", () => {
-    navigateAndVerify("/tasks");
-    cy.get('[data-cy="todo-list"]').should("exist");
+  it("should allow adding a new category", () => {
+    // Confirm the form for adding categories is visible
+    checkElementVisibility(
+      '[data-cy="category-name-input"]',
+      "Category name input is visible",
+      "Category name input is not visible"
+    );
+    checkElementVisibility(
+      '[data-cy="category-description-input"]',
+      "Category description input is visible",
+      "Category description input is not visible"
+    );
+    checkElementVisibility(
+      '[data-cy="category-add-button"]',
+      "Add category button is visible",
+      "Add category button is not visible"
+    );
+
+    // Add a new category
+    cy.get('[data-cy="category-name-input"]').type("New Category");
+    cy.get('[data-cy="category-description-input"]').type("Test tasks");
+    cy.get('[data-cy="category-add-button"]').click();
+
+    // Wait for the POST request and verify the new category is displayed
+    cy.wait("@addCategoryRequest").its("response.statusCode").should("eq", 201);
+    checkElementVisibility(
+      '[data-cy="category-name-3"]',
+      "New category is visible",
+      "New category is not visible"
+    );
   });
 
-  it("should display profile when redirected to profile page", () => {
-    navigateAndVerify("/profile");
-    cy.get("body").then(($body) => {
-      if ($body.find('[data-cy="edit-profile-title"]').length > 0) {
-        cy.log("Profile page loaded");
-        cy.get('[data-cy="edit-profile-title"]').should("exist");
-      } else {
-        cy.log("Profile page not loaded");
-      }
-    });
+  it("should allow the user to delete a category", () => {
+    // Confirm the category exists before deletion
+    checkElementVisibility(
+      '[data-cy="category-name-1"]',
+      "Category 'Work' is visible before deletion",
+      "Category 'Work' is not visible before deletion"
+    );
+
+    // Simulate deleting the category
+    cy.get('[data-cy="delete-category-1"]').click();
+
+    // Wait for the DELETE request and verify the category is removed
+    cy.wait("@deleteCategoryRequest").its("response.statusCode").should("eq", 200);
+    cy.get('[data-cy="category-name-1"]').should("not.exist");
   });
 
   after(() => {
+    // Delete test user after tests
     cy.deleteUser("test@example.com", "password123");
   });
 });

--- a/cypress/e2e/dashboard.cy.ts
+++ b/cypress/e2e/dashboard.cy.ts
@@ -51,13 +51,13 @@ describe("Dashboard Page E2E", () => {
   it("should display todo list component on dashboard", () => {
     cy.get('[data-cy="menu-toggle-button"]').click();
     cy.get('[data-cy="sidebar-view-tasks"]').click();
-  
+
     // Ensure the sidebar menu item is visible and scroll into view
     cy.get('[data-cy="sidebar-tasks-cards"]')
       .scrollIntoView()
       .should("be.visible")
       .click();
-  
+
     checkElementVisibility(
       '[data-cy="todo-list"]',
       "Todo list component loaded successfully",
@@ -66,17 +66,21 @@ describe("Dashboard Page E2E", () => {
   });
 
   it("should display categories component from the menu on dashboard", () => {
-    // Click the menu toggle button and navigate to categories
+    // Click the menu toggle button to open the sidebar
     cy.get('[data-cy="menu-toggle-button"]').click();
-    cy.get('[data-cy="sidebar-categories"]').click();
-  
-    // Check if the categories list is visible
-    checkElementVisibility(
-      '[data-cy="category-list-items"]',
-      "Categories component loaded successfully",
-      "Categories component did not load"
-    );
-  });  
+
+    // Click the categories option in the sidebar and wait for the page to respond
+    cy.get('[data-cy="sidebar-categories"]').should("be.visible").click();
+
+    // Log for debugging
+    cy.log("Sidebar categories clicked, waiting for category list to load...");
+
+    // Check if the categories list is present and visible
+    cy.get('[data-cy="category-list-items"]', { timeout: 10000 })
+      .scrollIntoView()
+      .should("exist")
+      .and("be.visible");
+  });
 
   it("should display profile component from the menu on dashboard", () => {
     cy.get('[data-cy="menu-toggle-button"]').click();

--- a/cypress/e2e/dashboard.cy.ts
+++ b/cypress/e2e/dashboard.cy.ts
@@ -1,33 +1,55 @@
 /// <reference types="cypress" />
 
-import { navigateAndVerify, checkElementVisibility } from "../support/utils";
+import { checkElementVisibility } from "../support/utils";
 
 describe("Dashboard Page E2E", () => {
-  let token;
-
-  before(() => {
-    // Create a user with custom profile data for testing the dashboard
-    cy.resetUser("test@example.com", "password123", {
-      firstName: "Jane",
-      lastName: "Smith",
-      nickname: "JaneS",
-      username: "janesmith",
-    }).then((response) => {
-      token = response.body.token; // Store the token for API requests
-    });
-  });
-
   beforeEach(() => {
-    // Intercept the login request before the test
-    cy.intercept("POST", "/api/auth/login").as("loginRequest");
+    // Mock for login endpoint
+    cy.intercept("POST", "/api/auth/login", {
+      statusCode: 200,
+      body: {
+        success: true,
+        token: "valid-token", // Simulates a valid authentication token
+      },
+    }).as("loginRequest");
 
-    // Use the custom login function
-    cy.login("test@example.com", "password123", "/login");
+    // Mock for authentication check endpoint
+    cy.intercept("GET", "/api/auth/check", {
+      statusCode: 200,
+      body: { success: true }, // Indicates the session is valid
+    }).as("authCheck");
 
-    // Wait for the intercepted login request and assert the response
-    cy.wait("@loginRequest").then((interception) => {
-      expect(interception.response.statusCode).to.equal(200);
-    });
+    // Mock for user profile endpoint
+    cy.intercept("GET", "/api/users/profile", {
+      statusCode: 200,
+      body: {
+        success: true,
+        user: {
+          id: "123",
+          name: "Test User",
+          email: "test@example.com",
+        },
+      },
+    }).as("userProfile");
+
+    // Mock for fetching categories
+    cy.intercept("GET", "/api/categories", {
+      statusCode: 200,
+      body: {
+        success: true,
+        categories: [
+          { _id: "1", name: "Work", description: "Work-related tasks" },
+          { _id: "2", name: "Personal", description: "Personal tasks" },
+        ],
+      },
+    }).as("categoriesRequest");
+
+    // Simulate login
+    cy.visit("/login");
+    cy.get('input[id="email"]').type("test@example.com");
+    cy.get('input[id="password"]').type("password123");
+    cy.get('button[type="submit"]').click();
+    cy.wait("@loginRequest").its("response.statusCode").should("eq", 200);
   });
 
   it("should display user information on the dashboard", () => {
@@ -51,12 +73,7 @@ describe("Dashboard Page E2E", () => {
   it("should display todo list component on dashboard", () => {
     cy.get('[data-cy="menu-toggle-button"]').click();
     cy.get('[data-cy="sidebar-view-tasks"]').click();
-
-    // Ensure the sidebar menu item is visible and scroll into view
-    cy.get('[data-cy="sidebar-tasks-cards"]')
-      .scrollIntoView()
-      .should("be.visible")
-      .click();
+    cy.get('[data-cy="sidebar-tasks-cards"]').click();
 
     checkElementVisibility(
       '[data-cy="todo-list"]',
@@ -66,20 +83,29 @@ describe("Dashboard Page E2E", () => {
   });
 
   it("should display categories component from the menu on dashboard", () => {
-    // Click the menu toggle button to open the sidebar
+    // Mock response ensures predictable data
+    cy.intercept("GET", "/api/categories", {
+      statusCode: 200,
+      body: {
+        success: true,
+        categories: [
+          { _id: "1", name: "Work", description: "Work-related tasks" },
+          { _id: "2", name: "Personal", description: "Personal tasks" },
+        ],
+      },
+    }).as("categoriesRequest");
+
     cy.get('[data-cy="menu-toggle-button"]').click();
+    cy.get('[data-cy="sidebar-categories"]').click();
 
-    // Click the categories option in the sidebar and wait for the page to respond
-    cy.get('[data-cy="sidebar-categories"]').should("be.visible").click();
+    // Wait for the mocked API request
+    cy.wait("@categoriesRequest").its("response.statusCode").should("eq", 200);
 
-    // Log for debugging
-    cy.log("Sidebar categories clicked, waiting for category list to load...");
-
-    // Check if the categories list is present and visible
-    cy.get('[data-cy="category-list-items"]', { timeout: 10000 })
-      .scrollIntoView()
-      .should("exist")
-      .and("be.visible");
+    checkElementVisibility(
+      '[data-cy="category-list-items"]',
+      "Categories component loaded successfully",
+      "Categories component did not load"
+    );
   });
 
   it("should display profile component from the menu on dashboard", () => {
@@ -90,9 +116,5 @@ describe("Dashboard Page E2E", () => {
       "Profile component loaded successfully",
       "Profile component did not load"
     );
-  });
-
-  after(() => {
-    cy.deleteUser("test@example.com", "password123");
   });
 });

--- a/cypress/e2e/dashboard.cy.ts
+++ b/cypress/e2e/dashboard.cy.ts
@@ -51,7 +51,13 @@ describe("Dashboard Page E2E", () => {
   it("should display todo list component on dashboard", () => {
     cy.get('[data-cy="menu-toggle-button"]').click();
     cy.get('[data-cy="sidebar-view-tasks"]').click();
-    cy.get('[data-cy="sidebar-tasks-cards"]').click();
+  
+    // Ensure the sidebar menu item is visible and scroll into view
+    cy.get('[data-cy="sidebar-tasks-cards"]')
+      .scrollIntoView()
+      .should("be.visible")
+      .click();
+  
     checkElementVisibility(
       '[data-cy="todo-list"]',
       "Todo list component loaded successfully",
@@ -60,14 +66,17 @@ describe("Dashboard Page E2E", () => {
   });
 
   it("should display categories component from the menu on dashboard", () => {
+    // Click the menu toggle button and navigate to categories
     cy.get('[data-cy="menu-toggle-button"]').click();
     cy.get('[data-cy="sidebar-categories"]').click();
+  
+    // Check if the categories list is visible
     checkElementVisibility(
       '[data-cy="category-list-items"]',
       "Categories component loaded successfully",
       "Categories component did not load"
     );
-  });
+  });  
 
   it("should display profile component from the menu on dashboard", () => {
     cy.get('[data-cy="menu-toggle-button"]').click();

--- a/cypress/e2e/filterModal.cy.ts
+++ b/cypress/e2e/filterModal.cy.ts
@@ -1,38 +1,33 @@
-/// <reference types="cypress" />
-
-import { navigateAndVerify, checkElementVisibility } from "../support/utils";
-
 describe("Filter Modal E2E", () => {
   let token;
 
+  // Sets up the user before all tests
   before(() => {
-    // Resets the user before all tests
     cy.resetUser("test@example.com", "password123", {
       firstName: "Jane",
       lastName: "Smith",
       nickname: "JaneS",
       username: "janesmith",
     }).then((response) => {
-      token = response.body.token; // Store the token for API requests
+      token = response.body.token;
     });
   });
 
   beforeEach(() => {
-    // Login and navigate to the tasks page
     cy.intercept("POST", "/api/auth/login").as("loginRequest");
     cy.login("test@example.com", "password123", "/dashboard");
     cy.wait("@loginRequest").then((interception) => {
       expect(interception.response?.statusCode).to.equal(200);
     });
 
-    // Open the menu and navigate to the tasks page
+    // Open the menu to access the Tasks page
     cy.get('[data-cy="menu-toggle-button"]').click();
     cy.get('[data-cy="sidebar-view-tasks"]').click();
     cy.wait(500);
     cy.get('[data-cy="sidebar-tasks-cards"]').click();
     cy.wait(500);
 
-    // Add a task with high priority
+    // Adds a task with high priority
     const taskTitle = `High Priority Task ${Date.now()}`;
     const taskResume = `Resume for ${taskTitle}`;
     cy.get('[data-cy="button-add-task"]').click();
@@ -44,25 +39,16 @@ describe("Filter Modal E2E", () => {
 
     cy.wait(1000);
     cy.get('[data-cy="add-task-button"]').click({ force: true });
-    checkElementVisibility(
-      `[data-cy^="task-"]:contains("${taskTitle}")`,
-      "Task with high priority added successfully",
-      "Task with high priority was not added"
-    );
+    cy.contains(taskTitle).should("be.visible");
   });
 
   it("should open the filter modal and apply a priority filter", () => {
-    // Open the filter modal
     cy.wait(2000);
     cy.get('[data-cy="filter-modal-button"]').click();
-    checkElementVisibility(
-      '[data-cy="filter-modal"]',
-      "Filter modal opened successfully",
-      "Filter modal did not open"
-    );
+    cy.get('[data-cy="filter-modal"]').should("be.visible");
 
-    // Apply the high-priority filter
     cy.get('[data-cy="priority-filter-high"]').click();
+
     cy.get('[data-cy="task-list"]')
       .find('[data-cy^="task-"]')
       .should("have.length.greaterThan", 0)
@@ -70,32 +56,20 @@ describe("Filter Modal E2E", () => {
         cy.wrap($task).should("contain.text", "High");
       });
 
-    // Close the modal and handle confirmation
     cy.get('[data-cy="close-modal-button"]').click();
-    checkElementVisibility(
-      '[data-cy="confirmation-modal"]',
-      "Confirmation modal opened on close",
-      "Confirmation modal did not open on close"
-    );
+    cy.get('[data-cy="confirmation-modal"]').should("be.visible");
     cy.get('[data-cy="cancel-clear-filters"]').click();
     cy.get('[data-cy="filter-modal"]').should("not.exist");
   });
 
   it("should show confirmation modal when closing and clear filters on confirm", () => {
-    // Open the filter modal and apply a filter
     cy.get('[data-cy="filter-modal-button"]').click();
     cy.get('[data-cy="priority-filter-medium"]').click();
 
-    // Close the modal and confirm filter clearing
     cy.get('[data-cy="close-modal-button"]').click();
-    checkElementVisibility(
-      '[data-cy="confirmation-modal"]',
-      "Confirmation modal opened successfully",
-      "Confirmation modal did not open"
-    );
+    cy.get('[data-cy="confirmation-modal"]').should("be.visible");
     cy.get('[data-cy="confirm-clear-filters"]').click();
 
-    // Verify the filter modal closes and tasks are visible
     cy.get('[data-cy="filter-modal"]').should("not.exist");
     cy.get('[data-cy="task-list"]').within(() => {
       cy.get('[data-cy^="task-"]').should("exist");

--- a/cypress/e2e/profile.cy.ts
+++ b/cypress/e2e/profile.cy.ts
@@ -87,23 +87,26 @@ describe("Profile Page E2E", () => {
   }); 
 
   it("should prevent access to profile page if not authenticated", () => {
-    // Mock the /api/auth/check endpoint to return 401
+    // Mock the auth check response to simulate an unauthenticated user
     cy.intercept("GET", "/api/auth/check", {
-      statusCode: 401,
+      statusCode: 401, // Simulate unauthorized response
       body: { success: false, message: "Unauthorized" },
     }).as("authCheck");
   
-    // Logout to test unauthorized access
+    // Perform logout to clear authentication state
     cy.logout();
   
     // Attempt to visit the profile page
     cy.visit("/profile");
   
-    // Wait for the unauthorized check and verify redirection
-    cy.wait("@authCheck");
-    cy.url({ timeout: 5000 }).should("include", "/login?message=no_token");
-  });
+    // Wait for the auth check request and validate the response
+    cy.wait("@authCheck").then((interception) => {
+      expect(interception.response.statusCode).to.equal(401);
+    });
   
+    // Verify redirection to the login page with appropriate message
+    cy.url({ timeout: 5000 }).should("include", "/login?message=no_token");
+  });  
 
   after(() => {
     // Delete test user after tests

--- a/cypress/e2e/profile.cy.ts
+++ b/cypress/e2e/profile.cy.ts
@@ -56,29 +56,35 @@ describe("Profile Page E2E", () => {
 
   it("should allow users to update their profile", () => {
     const newFirstName = "UpdatedFirstName";
-
+  
     cy.get("body").then(($body) => {
       if ($body.find('[data-cy="first-name-input"]').length > 0) {
         cy.log("Profile edit form loaded successfully");
-        
-        // Update profile fields
-        cy.get('[data-cy="first-name-input"]').clear().type(newFirstName);
+  
+        // Ensure the field is cleared before typing
+        cy.get('[data-cy="first-name-input"]')
+          .invoke("val") // Get the current value
+          .then((currentValue) => {
+            cy.log(`Current value: ${currentValue}`);
+            cy.get('[data-cy="first-name-input"]').clear().type(newFirstName);
+          });
+  
         cy.get('[data-cy="bio-textarea"]').clear().type("This is an updated bio.");
-        
+  
         // Scroll to and click the "Save Profile" button
         cy.get('[data-cy="save-profile"]')
           .scrollIntoView()
           .should("be.visible")
           .click();
-
-        // Verify profile update success message
+  
+        // Verify profile update success message and final value
         cy.get('[data-cy="first-name-input"]').should("have.value", newFirstName);
         cy.get('[data-cy="success-message"]').should("exist");
       } else {
         cy.log("Profile edit form did not load");
       }
     });
-  });
+  }); 
 
   it("should prevent access to profile page if not authenticated", () => {
     // Logout to test unauthorized access

--- a/cypress/e2e/profile.cy.ts
+++ b/cypress/e2e/profile.cy.ts
@@ -87,13 +87,23 @@ describe("Profile Page E2E", () => {
   }); 
 
   it("should prevent access to profile page if not authenticated", () => {
+    // Mock the /api/auth/check endpoint to return 401
+    cy.intercept("GET", "/api/auth/check", {
+      statusCode: 401,
+      body: { success: false, message: "Unauthorized" },
+    }).as("authCheck");
+  
     // Logout to test unauthorized access
     cy.logout();
-
+  
     // Attempt to visit the profile page
     cy.visit("/profile");
+  
+    // Wait for the unauthorized check and verify redirection
+    cy.wait("@authCheck");
     cy.url({ timeout: 5000 }).should("include", "/login?message=no_token");
   });
+  
 
   after(() => {
     // Delete test user after tests

--- a/locales/en.json
+++ b/locales/en.json
@@ -56,7 +56,8 @@
     "errorFetchingCategories": "Failed to fetch categories.",
     "errorLoadingCategories": "Failed to load categories. Please try again.",
     "errorAddingCategory": "Failed to add category.",
-    "errorDeletingCategory": "Failed to delete category."
+    "errorDeletingCategory": "Failed to delete category.",
+    "emptyMessage": "No categories available. Start by adding a new category!"
   },
   "tasksPage": {
     "title": "Your To-Do List",

--- a/locales/es.json
+++ b/locales/es.json
@@ -56,7 +56,8 @@
     "errorFetchingCategories": "Error al obtener categorías.",
     "errorLoadingCategories": "Error al cargar categorías. Por favor, intenta nuevamente.",
     "errorAddingCategory": "Error al agregar la categoría.",
-    "errorDeletingCategory": "Error al eliminar la categoría."
+    "errorDeletingCategory": "Error al eliminar la categoría.",
+    "emptyMessage": "No hay categorías disponibles. ¡Empieza añadiendo una nueva categoría!"
   },
   "tasksPage": {
     "title": "Tu Lista de Tareas",

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -56,7 +56,8 @@
     "errorFetchingCategories": "Falha ao buscar categorias.",
     "errorLoadingCategories": "Falha ao carregar categorias. Por favor, tente novamente.",
     "errorAddingCategory": "Falha ao adicionar categoria.",
-    "errorDeletingCategory": "Falha ao excluir categoria."
+    "errorDeletingCategory": "Falha ao excluir categoria.",
+    "emptyMessage": "Nenhuma categoria disponível. Comece adicionando uma nova categoria!"
   },
   "tasksPage": {
     "title": "Sua Lista de Tarefas",


### PR DESCRIPTION
### **Feature: Add i18n support and stabilize Cypress tests**

---

### **Description**

#### **Key Features**
- **Internationalization (i18n) Support:**
  - Added support for English, Portuguese, and Spanish.
  - Implemented a language selector in the user profile menu (visible only to logged-in users).

#### **Cypress Test Stabilization**
- Improved `checkElementVisibility` and `navigateAndVerify` utilities for consistency across tests.
- Adjusted failing tests to prevent flakiness:
  - Fixed issues with element overlap during sidebar navigation.
  - Corrected assertions in `Profile Page E2E` for profile updates.
- Verified stability of all tests locally using:
  ```bash
  npx cypress run --headless --config baseUrl=https://personal-task-tracker-nine.vercel.app
